### PR TITLE
Converting into IP address

### DIFF
--- a/A-code-to-Converting-into-IP-address.txt
+++ b/A-code-to-Converting-into-IP-address.txt
@@ -1,0 +1,20 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+void binaryToMac(const char* binary) {
+    unsigned int bytes[6] = {0};
+    for (int i = 0; i < 48; ++i) {
+        bytes[i / 8] = (bytes[i / 8] << 1) | (binary[i] - '0');
+    }
+    printf("MAC Address: %02X:%02X:%02X:%02X:%02X:%02X\n",
+           bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5]);
+}
+
+int main() {
+    char binary_pattern[49];
+    printf("Example of a 48-bit binary pattern: 101010101011101111001100110111011110111111111111\n");
+    printf("Enter a 48-bit binary pattern: ");
+    scanf("%48s", binary_pattern);
+    binaryToMac(binary_pattern);
+    return 0;
+}


### PR DESCRIPTION
To convert a 32-bit unsigned integer into an IP address format. The IP address format typically consists of four octets separated by periods (e.g., 192.168.1.1).

Here's a brief overview of how the code works:

It defines four macros, BYTE1, BYTE2, BYTE3, and BYTE4, which extract the individual bytes of the 32-bit integer representing an IP address. In the main function, it prompts the user to input a 32-bit unsigned integer (the packed IP address). It then reads the input and passes it to the macros to extract the four bytes representing the IP address. Finally, it prints the IP address in the standard dotted-decimal notation.